### PR TITLE
bpi-resource-attributes-max-lenght excludes enumeration

### DIFF
--- a/docs/specification-rules/fill.md
+++ b/docs/specification-rules/fill.md
@@ -40,7 +40,7 @@ Each operation must have an operationId that is its path, with - instead of / an
 
 ## bpi-resource-attributes-max-lenght
 
-In order to limit the size of the payload, every string attribute and format other than date, time and date-time, must have a max length validation.
+In order to limit the size of the payload, every string attribute and format other than date, time, date-time and enumeration, must have a max length validation.
 
 ![bpi-resource-attributes-max-lenght](https://raw.github.com/bancobpi/style-guide/main/static/bpi-resource-attributes-max-lenght.jpg)
 

--- a/spectral-fill-rules.yml
+++ b/spectral-fill-rules.yml
@@ -62,7 +62,7 @@ rules:
     documentationUrl: https://bancobpi.stoplight.io/docs/style-guide/ZG9jOjUxMTY4Nzk2-fill-rules-specification#bpi-resource-attributes-max-lenght
     recommended: true
     type: style
-    given: $..properties[?(@.type == "string" && @.format !== "date" && @.format !== "time" && @.format !== "date-time")]*
+    given: $..properties[?(@.type == "string" && @.format !== "date" && @.format !== "time" && @.format !== "date-time"  && !@.enum)]*
     severity: error
     then:
       - field: maxLength


### PR DESCRIPTION
Remove enumeration from validation maxLenght in rule bpi-resource-attributes-max-lenght