### PR TITLE
Fix previous rules

### DIFF
--- a/functions/query-parameters-pagination.js
+++ b/functions/query-parameters-pagination.js
@@ -22,12 +22,12 @@ export default (targetValue,options, context) => {
             message: "GET List MUST have pagination query parameters 'pageNumber' and 'pageSize'."
           });
         }else{
-          if(pagintationParams[0].required && pagintationParams[1].required) {
+          if((pagintationParams[0].required || pagintationParams[0].schema.default) && (pagintationParams[1].required || pagintationParams[1].schema.default)) {
             return result;
           }
           else {
             result.push({
-              message: "'pageNumber' and 'pageSize' MUST be required."
+              message: "'pageNumber' and 'pageSize' MUST be required or have a default value."
             });
           }
         } 

--- a/functions/validate-resource-description.js
+++ b/functions/validate-resource-description.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (input, options, context) => {
+  const path = context.path.toString();
+
+  // Ensures that the properties from the x-bpi-field-metadata are not considered
+  if(!path.includes("x-bpi-field-metadata") && input.description == undefined) {
+    return [
+      {
+        message: "Model properties SHOULD have a description"
+      }
+    ]
+  }
+};

--- a/spectral-fill-rules.yml
+++ b/spectral-fill-rules.yml
@@ -4,18 +4,18 @@ functions:
   - includes-string
   - validate-scopes
   - validate-resource-title
+  - validate-resource-description
   
 rules:
   bpi-resource-attributes-description:
     description: Every attribute inside properties SHOULD have the description.
-    message: Model properties SHOULD have a description.
+    message: "{{error}}"
     documentationUrl: https://bancobpi.stoplight.io/docs/style-guide/b7c5ed794d032-fill#bpi-resource-attributes-description
     severity: warn
-    given: $..properties[?(@.type !== "object" && @.name !== "formatoConta" && @.name !== "tipoUtilizacao" && @.name !== "integridade")]*
+    given: $..properties[?(@.type !== "object")]*
     recommended: true
     then:
-      field: description
-      function: truthy
+      function: validate-resource-description
 
   bpi-resource-attributes-examples:
     description: Model property `examples` SHOULD be present and non-empty string.

--- a/spectral-fill-rules.yml
+++ b/spectral-fill-rules.yml
@@ -54,7 +54,7 @@ rules:
     message: "{{error}}"
     documentationUrl: https://bancobpi.stoplight.io/docs/style-guide/b7c5ed794d032-fill#bpi-validate-operation-id
     severity: warn
-    given: $.paths..operationId
+    given: $.paths.*.*.operationId
     then:
       function: operation-id
 


### PR DESCRIPTION
This PR covers the following:
- pageNumber and pageSize must be required or default
- Rule for attribute descriptions is now disconsidering properties from x-bpi-field-metadata
- operationId json path fixed, so the rule is not applied to attributes with "operationId" as their name